### PR TITLE
Fixes binhex/arch-int-openvpn#9

### DIFF
--- a/run/root/getdns.sh
+++ b/run/root/getdns.sh
@@ -15,7 +15,7 @@ if [[ "${VPN_ENABLED}" == "yes" ]]; then
 
 		# check we can resolve names before continuing (required for getvpnextip.sh script)
 		# note -v 'SERVER' is to prevent name server ip being matched from stdout
-		remote_dns_answer=$(drill -4 "${1}" 2> /dev/null | grep -v 'SERVER' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | xargs)
+		remote_dns_answer=$(drill -a -4 "${1}" 2> /dev/null | grep -v 'SERVER' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | xargs)
 
 		# check answer is not blank, if it is blank assume bad ns
 		if [[ ! -z "${remote_dns_answer}" ]]; then

--- a/run/root/getvpnextip.sh
+++ b/run/root/getvpnextip.sh
@@ -25,7 +25,7 @@ function get_external_ip_ns() {
 	site="${2}"
 
 	# note -v 'SERVER' is to prevent name server ip being matched from stdout
-	external_ip="$(drill -I ${vpn_ip} -4 ${ns_query} ${site} | grep -v 'SERVER' | grep -oP '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+	external_ip="$(drill -a -I ${vpn_ip} -4 ${ns_query} ${site} | grep -v 'SERVER' | grep -m 63 -oP '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
 	check_valid_ip "${external_ip}"
 	return_code="$?"
 
@@ -158,7 +158,7 @@ if [[ "${APPLICATION}" != "sabnzbd" ]] && [[ "${APPLICATION}" != "privoxy" ]]; t
 
 		echo "[warn] Cannot determine external IP address, performing tests before setting to '127.0.0.1'..."
 		echo "[info] Show name servers defined for container" ; cat /etc/resolv.conf
-		echo "[info] Show name resolution for VPN endpoint ${VPN_REMOTE}" ; drill -I ${vpn_ip} -4 "${VPN_REMOTE}"
+		echo "[info] Show name resolution for VPN endpoint ${VPN_REMOTE}" ; drill -a -I ${vpn_ip} -4 "${VPN_REMOTE}"
 		echo "[info] Show contents of hosts file" ; cat /etc/hosts
 
 		# write external ip address to text file, this is then read by the downloader script

--- a/run/root/start.sh
+++ b/run/root/start.sh
@@ -102,7 +102,7 @@ else
 
 		# get answer for remote endpoint from ns, used later on in openvpn.sh to specify multiple --remote entries
 		# note -v 'SERVER' is to prevent name server ip being matched from stdout
-		remote_dns_answer=$(drill -4 "${VPN_REMOTE}" | grep -v 'SERVER' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | xargs)
+		remote_dns_answer=$(drill -a -4 "${VPN_REMOTE}" | grep -v 'SERVER' | grep -m 63 -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | xargs)
 
 		# check answer is not blank, if it is blank assume bad ns
 		if [[ ! -z "${remote_dns_answer}" ]]; then
@@ -176,7 +176,7 @@ else
 
 	if [[ "${DEBUG}" == "true" ]]; then
 		echo "[debug] Show name servers defined for container" ; cat /etc/resolv.conf
-		echo "[debug] Show name resolution for VPN endpoint ${VPN_REMOTE}" ; drill "${VPN_REMOTE}"
+		echo "[debug] Show name resolution for VPN endpoint ${VPN_REMOTE}" ; drill -a "${VPN_REMOTE}"
 		echo "[debug] Show contents of hosts file" ; cat /etc/hosts
 	fi
 


### PR DESCRIPTION
* Sets the '-a' flag for drill, so on large responses it can
automatically fall back to TCP
* Sets the '-m 63' flag for grep, since OpenVPN is limited to 64 remotes